### PR TITLE
don't require should

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
-
 test:
 	@./node_modules/.bin/mocha \
-		--require should \
 		--reporter spec
 
 .PHONY: test


### PR DESCRIPTION
so that `make test` works.
