### PR TITLE
add fix for non-string name fields

### DIFF
--- a/lib/identify.js
+++ b/lib/identify.js
@@ -122,7 +122,7 @@ Identify.prototype.companyCreated = function(){
 
 Identify.prototype.name = function () {
   var name = this.proxy('traits.name');
-  if (name) return trim(name);
+  if (typeof name === 'string') return trim(name);
 
   var firstName = this.firstName();
   var lastName = this.lastName();
@@ -138,10 +138,10 @@ Identify.prototype.name = function () {
 
 Identify.prototype.firstName = function () {
   var firstName = this.proxy('traits.firstName');
-  if (firstName) return trim(firstName);
+  if (typeof firstName === 'string') return trim(firstName);
 
   var name = this.proxy('traits.name');
-  if (name) return trim(name).split(' ')[0];
+  if (typeof name === 'string') return trim(name).split(' ')[0];
 };
 
 /**
@@ -153,10 +153,10 @@ Identify.prototype.firstName = function () {
 
 Identify.prototype.lastName = function () {
   var lastName = this.proxy('traits.lastName');
-  if (lastName) return trim(lastName);
+  if (typeof lastName === 'string') return trim(lastName);
 
   var name = this.proxy('traits.name');
-  if (!name) return;
+  if (typeof name !== 'string') return;
 
   var space = trim(name).indexOf(' ');
   if (space === -1) return;

--- a/test/identify.js
+++ b/test/identify.js
@@ -152,6 +152,25 @@ describe('Identify', function () {
       });
       expect(identify.name()).to.eql(firstName + ' ' + lastName);
     });
+
+    it('should not throw on a non-string', function () {
+      var identify = new Identify({
+        traits: {
+          name: {}
+        }
+      });
+      expect(identify.name()).to.eql(undefined);
+    });
+
+    it('should not throw on a non-string pair', function () {
+      var identify = new Identify({
+        traits: {
+          firstName: {},
+          lastName: {}
+        }
+      });
+      expect(identify.name()).to.eql(undefined);
+    });
   });
 
 
@@ -168,6 +187,15 @@ describe('Identify', function () {
     it('should pull from a passed in name', function () {
       var identify = new Identify({ traits : { name : name }});
       expect(identify.firstName()).to.eql(firstName);
+    });
+
+    it('should not fail on a non-string', function () {
+      var identify = new Identify({
+        traits: {
+          firstName: {}
+        }
+      });
+      expect(identify.firstName()).to.eql(undefined);
     });
   });
 
@@ -190,6 +218,15 @@ describe('Identify', function () {
     it('should split and trim the full lastName properly', function () {
       var identify = new Identify({ traits: { name: 'Freddie  Mercury III' }});
       expect(identify.lastName()).to.eql('Mercury III');
+    });
+
+    it('should not fail on a non-string', function () {
+      var identify = new Identify({
+        traits: {
+          lastName: {}
+        }
+      });
+      expect(identify.lastName()).to.eql(undefined);
     });
   });
 


### PR DESCRIPTION
This commit adds a fix for non-string `name`, `firstName`, and `lastName`
traits. A user was passing in objects to these fields, which will throw an
exception when passed to `trim`.

cc @yields 
