### PR TITLE
fix empty page#fullName()

### DIFF
--- a/lib/page.js
+++ b/lib/page.js
@@ -71,9 +71,9 @@ Page.prototype.properties = function(){
 Page.prototype.fullName = function(){
   var category = this.category();
   var name = this.name();
-  return name && category
-    ? category + ' ' + name
-    : name;
+  if (name && category) return category + ' ' + name;
+  if (name) return name;
+  return this.properties().path;
 };
 
 /**

--- a/test/page.js
+++ b/test/page.js
@@ -116,6 +116,15 @@ describe('Page', function(){
 
       expect(page.fullName()).to.eql('cat baz');
     })
+
+    it('should return the url when category and name are omitted', function(){
+      var page = new Page({
+        properties: {
+          path: '/foobar'
+        }
+      });
+      expect(page.fullName()).to.eql('/foobar');
+    })
   })
 
 })


### PR DESCRIPTION
name and category are optional for `page` calls
