### PR TITLE
fix: total() vs revenue()

### DIFF
--- a/lib/track.js
+++ b/lib/track.js
@@ -5,6 +5,7 @@ var Facade = component('./facade');
 var Identify = component('./identify');
 var inherit = component('inherit');
 var isEmail = component('is-email');
+var dot = require('obj-case');
 
 /**
  * Expose `Track` facade.
@@ -70,7 +71,6 @@ Track.prototype.sku = Facade.proxy('properties.sku');
 Track.prototype.tax = Facade.proxy('properties.tax');
 Track.prototype.name = Facade.proxy('properties.name');
 Track.prototype.price = Facade.proxy('properties.price');
-Track.prototype.total = Facade.proxy('properties.total');
 Track.prototype.coupon = Facade.proxy('properties.coupon');
 Track.prototype.shipping = Facade.proxy('properties.shipping');
 
@@ -227,15 +227,31 @@ Track.prototype.email = function () {
  */
 
 Track.prototype.revenue = function () {
-  var revenue = this.proxy('properties.revenue');
-  var event = this.event();
+  var revenue = dot(this.obj, 'properties.revenue');
 
-  // it's always revenue, unless it's called during an order completion.
-  if (!revenue && event && event.match(/completed ?order/i)) {
-    revenue = this.proxy('properties.total');
+  // only if it's `null` / `undefined`.
+  if (null == revenue) {
+    revenue = dot(this.obj, 'properties.total');
   }
 
   return currency(revenue);
+};
+
+/**
+ * Get the call's total, parsing it from a string, falling back to revenue.
+ * 
+ * @return {Number}
+ */
+
+Track.prototype.total = function(){
+  var total = dot(this.obj, 'properties.total');
+
+  // only if it's `null` / `undefiend`.
+  if (null == total) {
+    total = dot(this.obj, 'properties.revenue');
+  }
+
+  return currency(total) || total;
 };
 
 /**

--- a/test/track.js
+++ b/test/track.js
@@ -147,6 +147,21 @@ describe('Track', function(){
       var track = new Track({ properties: { total: 'total' } });
       expect(track.total()).to.eql('total');
     })
+
+    it('should remove `$` prefix', function(){
+      var track = new Track({ properties: { total: '$29.99' }});
+      expect(track.total()).to.eql(29.99);
+    })
+
+    it('should fallback to revenue', function(){
+      var track = new Track({ properties: { revenue: 99 }});
+      expect(track.total()).to.eql(99);
+    })
+
+    it('should remove `$` prefix', function(){
+      var track = new Track({ properties: { revenue: '$99' }});
+      expect(track.total()).to.eql(99);
+    })
   })
 
   describe('.coupon()', function(){
@@ -255,10 +270,8 @@ describe('Track', function(){
       expect(track.revenue()).to.eql(undefined);
     })
     
-    it('should fallback to total, only during "completed order" event', function(){
+    it('should fallback to total', function(){
       var track = new Track({ properties: { total: 75 } });
-      expect(track.revenue()).to.eql(undefined);
-      var track = new Track({ properties: { total: 75 }, event: 'completed order' });
       expect(track.revenue()).to.eql(75);
     });
   });


### PR DESCRIPTION
basically:
- `total()`: `ret total || revenue`.
- `revenue()`: `ret revenue || total`.

also i'm not using `.proxy()` since it's recursive.

cc @reinpk @calvinfo @travisjeffery 
