### PR TITLE
add `type` field to be returned from `.json()`

### DIFF
--- a/lib/facade.js
+++ b/lib/facade.js
@@ -96,7 +96,9 @@ Facade.field = function (field) {
  */
 
 Facade.prototype.json = function () {
-  return clone(this.obj);
+  var ret = clone(this.obj);
+  if (this.type) ret.type = this.type();
+  return ret;
 };
 
 /**

--- a/test/facade.js
+++ b/test/facade.js
@@ -56,6 +56,11 @@ describe('Facade', function (){
       var facade = new Facade(obj);
       expect(facade.json()).to.eql(obj);
     });
+
+    it('should add .type', function(){
+      var track = new Facade.Track({});
+      expect(track.json().type).to.eql('track');
+    });
   });
 
   describe('.context()', function(){


### PR DESCRIPTION
Adds the facade .type to the json payload so we don't have to do
it manually. Sets .json() to better match the spec

@yields @lancejpollard 
