### PR TITLE
adding groupId to context.groupId to support Totango

### DIFF
--- a/lib/facade.js
+++ b/lib/facade.js
@@ -196,6 +196,15 @@ Facade.prototype.anonymousId = function(){
 };
 
 /**
+ * Get `groupId` from `context.groupId`.
+ *
+ * @return {String}
+ * @api public
+ */
+
+Facade.prototype.groupId = Facade.proxy('options.groupId');
+
+/**
  * Add a convenient way to get the library name and version
  */
 

--- a/test/facade.js
+++ b/test/facade.js
@@ -206,6 +206,14 @@ describe('Facade', function (){
     });
   });
 
+  describe('.groupId()', function(){
+    it('should proxy the groupId', function(){
+      var groupId = 'groupId';
+      var facade = new Facade({ context: { groupId: groupId } });
+      expect(facade.groupId()).to.eql(groupId);
+    });
+  });
+
   describe('.channel()', function(){
     it('should return the channel', function(){
       var channel = 'english';


### PR DESCRIPTION
Just got off a call with Totango and @ianstormtaylor. Totango needs `sdr_o` on server-side calls which is their account level `groupId` on `identify`, `track`, `page`, and `screen` calls. Ian and I decided to put it in `context.groupId` until we support some kind of state or persistence server-side. 
