### PR TITLE
Marketo is no longer disabled by default

### DIFF
--- a/lib/is-enabled.js
+++ b/lib/is-enabled.js
@@ -5,8 +5,7 @@
  */
 
 var disabled = {
-  Salesforce: true,
-  Marketo: true
+  Salesforce: true
 };
 
 /**


### PR DESCRIPTION
This PR makes Marketo enabled by default **on Munchkin only** (client-side).

Why:
- Munchkin turned out not to work all, and Amir fixed it a few months ago, which means Munchkin will sync leads. We used to send all `identify` to the server-side so `syncLead` would actually work.
- We set it disabled by default because `syncLead` server-side was overwhelming Marketo's servers.
- Marketo's servers don't get overwhelmed with Munchkin.
  `analytics.page();` is a major function of Munchkin, and the current only way to get `visitWebPage` to fire is to call: `analytics.page('Title', {}, { Marketo: true });` which clearly no one is doing.
- Server-side won't activate anyway because of the `channel` check here: https://github.com/segmentio/integrations-private/blob/master/lib/marketo/index.js#L23

This PR basically allows Marketo client-side users to get Munchkin to work without weird syntax.
