### PR TITLE
updating 1-1 mapping for aliased .traits()

### DIFF
--- a/lib/identify.js
+++ b/lib/identify.js
@@ -62,7 +62,7 @@ Identify.prototype.traits = function (aliases) {
       : this[alias]();
     if (null == value) continue;
     ret[aliases[alias]] = value;
-    delete ret[alias];
+    if (alias !== aliases[alias]) delete ret[alias];
   }
 
   return ret;

--- a/test/identify.js
+++ b/test/identify.js
@@ -62,6 +62,20 @@ describe('Identify', function(){
         c: 'c'
       });
     })
+
+    it('should respect aliases which are a 1-1 mapping', function(){
+      var identify = new Identify({
+        traits: {
+          firstName: 'firstName',
+          lastName: 'lastName'
+        }
+      });
+      expect(identify.traits({ name: 'name' })).to.eql({
+        name: 'firstName lastName',
+        firstName: 'firstName',
+        lastName: 'lastName'
+      });
+    })
   });
 
 


### PR DESCRIPTION
Previously if there was a 1-1 mapping for the alias passed to
identify.traits(), we'd delete the trait.

@yields 
