### PR TITLE
adding benchmarks, moving traverse

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ node_modules: package.json
 test: node_modules
 	@./node_modules/.bin/mocha \
 		--reporter spec
+	@./node_modules/.bin/matcha bench.js
 
 test-browser: build
 	@$(DUO-TEST) browser /test --commands make

--- a/bench.js
+++ b/bench.js
@@ -1,0 +1,29 @@
+
+var Facade = require('./');
+var fixture = {
+  traits: {
+    websites:[
+      'foo.com',
+      'bar.com',
+      'baz.biz'
+    ],
+    created: new Date(),
+    date: '2014-01-01'
+  }
+};
+
+suite('Facade', function () {
+  var facade = new Facade(fixture);
+
+  bench('new Facade()', function(){
+    var facade = new Facade(fixture);
+  });
+
+  bench('.proxy', function(){
+    facade.proxy('traits');
+  });
+
+  bench('.field', function(){
+    facade.field('traits');
+  });
+});

--- a/lib/facade.js
+++ b/lib/facade.js
@@ -20,6 +20,7 @@ module.exports = Facade;
 function Facade (obj) {
   if (!obj.hasOwnProperty('timestamp')) obj.timestamp = new Date();
   else obj.timestamp = newDate(obj.timestamp);
+  traverse(obj);
   this.obj = obj;
 }
 
@@ -262,6 +263,5 @@ Facade.prototype.ip = Facade.proxy('options.ip');
 
 function transform(obj){
   var cloned = clone(obj);
-  traverse(cloned);
   return cloned;
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "duo": "0.1.0",
     "duo-test": "0.x",
     "expect.js": "~0.2.0",
+    "matcha": "^0.5.0",
     "mocha": "*",
     "mocha-phantomjs": "^3.5.0",
     "phantomjs": "^1.9.7-14"


### PR DESCRIPTION
Adding benchmark suite so we can compare regressions across
branches and also moved traverse out of the transform
function since that one is really hot when compared with creating
new Facade objects. Eventually we should get gnarlier fixtures
in there as well

@yields 
