### PR TITLE
group: add .email() that behaves like identify.email()

### DIFF
--- a/lib/group.js
+++ b/lib/group.js
@@ -5,6 +5,7 @@
 
 var inherit = require('./utils').inherit;
 var address = require('./address');
+var isEmail = require('is-email');
 var newDate = require('new-date');
 var Facade = require('./facade');
 
@@ -68,6 +69,19 @@ Group.prototype.created = function(){
     || this.proxy('properties.created');
 
   if (created) return newDate(created);
+};
+
+/**
+ * Get the group's email, falling back to the group ID if it's a valid email.
+ *
+ * @return {String}
+ */
+
+Group.prototype.email = function () {
+  var email = this.proxy('traits.email');
+  if (email) return email;
+  var groupId = this.groupId();
+  if (isEmail(groupId)) return groupId;
 };
 
 /**

--- a/test/group.js
+++ b/test/group.js
@@ -219,4 +219,21 @@ describe('Group', function(){
       expect(msg.industry()).to.eql('tech');
     });
   });
+
+  describe('.email()', function(){
+    it('should proxy email', function(){
+      var msg = new Group({ traits: { email: 'email@example.com' } });
+      expect(msg.email()).to.eql('email@example.com');
+    });
+
+    it('should fallback to .groupId if its a valid email', function(){
+      var msg = new Group({ groupId: 'email@example.com' });
+      expect(msg.email()).to.eql('email@example.com');
+    });
+
+    it('should not return the .groupId if its an invalid email', function(){
+      var msg = new Group({ groupId: 23 });
+      expect(msg.email()).to.eql(undefined);
+    });
+  });
 });


### PR DESCRIPTION
copied from `identify.email()`.
