### PR TITLE
adding facade.device() tests

### DIFF
--- a/lib/facade.js
+++ b/lib/facade.js
@@ -291,14 +291,32 @@ Facade.prototype.library = function(){
 };
 
 /**
+ * Return the device information or an empty object
+ *
+ * @return {Object}
+ */
+
+Facade.prototype.device = function(){
+  var device = this.proxy('context.device');
+  if (type(device) != 'object') device = {};
+  var library = this.library().name;
+  if (device.type) return device;
+
+  if (library.indexOf('ios') > -1) device.type = 'ios';
+  if (library.indexOf('android') > -1) device.type = 'android';
+  return device;
+}
+
+/**
  * Setup some basic proxies.
  */
 
-Facade.prototype.userId = Facade.field('userId');
-Facade.prototype.channel = Facade.field('channel');
+Facade.prototype.userAgent = Facade.proxy('context.userAgent');
+Facade.prototype.timezone = Facade.proxy('context.timezone');
 Facade.prototype.timestamp = Facade.field('timestamp');
-Facade.prototype.userAgent = Facade.proxy('options.userAgent');
-Facade.prototype.ip = Facade.proxy('options.ip');
+Facade.prototype.channel = Facade.field('channel');
+Facade.prototype.ip = Facade.proxy('context.ip');
+Facade.prototype.userId = Facade.field('userId');
 
 /**
  * Return the cloned and traversed object

--- a/test/facade.js
+++ b/test/facade.js
@@ -314,6 +314,14 @@ describe('Facade', function (){
     });
   });
 
+  describe('.timezone()', function(){
+    it('should return the timezone', function(){
+      var timezone = 'America/New_York';
+      var facade  = new Facade({ context : { timezone: timezone } });
+      expect(facade.timezone()).to.eql(timezone);
+    });
+  });
+
   describe('.timestamp()', function(){
     it('should return the current timestamp if none is supplied', function(){
       var facade = new Facade({});
@@ -392,6 +400,35 @@ describe('Facade', function (){
         name: 'analytics-node',
         version: 1.0
       });
+    });
+  });
+
+  describe('.device()', function(){
+    it('should return the device', function(){
+      var facade = new Facade({ context: { device: { token: 'token' }}});
+      expect(facade.device()).to.eql({ token: 'token' });
+    });
+
+    it('should leave existing device-types untouched', function(){
+      var facade = new Facade({
+        context: {
+          library: { name: 'analytics-ios' },
+          device: { type: 'browser' }
+        }
+      });
+      expect(facade.device().type).to.eql('browser');
+    });
+
+    it('should infer device.type when library.name is analytics-ios', function(){
+      var ios = { name: 'analytics-ios' };
+      var facade = new Facade({ context: { library: ios }});
+      expect(facade.device().type).to.eql('ios');
+    });
+
+    it('should infer device.type when library.name is analytics-android', function(){
+      var android = { name: 'analytics-android' };
+      var facade = new Facade({ context: { library: android }});
+      expect(facade.device().type).to.eql('android');
     });
   });
 


### PR DESCRIPTION
starting to spec out how `.device()` might work, since this will help clean up our push notification token mappings in commandiq, outbound, urban airship, etc.
