### PR TITLE
options: support legacy options

### DIFF
--- a/lib/facade.js
+++ b/lib/facade.js
@@ -164,8 +164,10 @@ Facade.prototype.options = function (integration) {
   if (!this.enabled(integration)) return;
   var integrations = this.integrations();
   var value = integrations[integration] || objCase(integrations, integration);
-  if ('boolean' == typeof value) value = {};
-  return value || {};
+  if ('object' != typeof value) value = objCase(this.options(), integration);
+  return 'object' == typeof value
+    ? value
+    : {};
 };
 
 /**

--- a/test/facade.js
+++ b/test/facade.js
@@ -82,6 +82,59 @@ describe('Facade', function (){
     });
   });
 
+  describe('.options(name)', function(){
+    var msg;
+
+    beforeEach(function(){
+      msg = new Facade({
+        context: {
+          Salesforce: {
+            object: 'Account'
+          }
+        },
+        integrations: {
+          Salesforce: true
+        }
+      });
+    });
+
+    it('should return the correct object', function(){
+      expect(msg.options('Salesforce')).to.eql({
+        object: 'Account'
+      });
+    });
+
+    it('should always return an object', function(){
+      delete msg.obj.context;
+      expect(msg.options('Salesforce')).to.eql({});
+    });
+
+    it('should lookup options using obj-case', function(){
+      expect(msg.options('salesforce')).to.eql({
+        object: 'Account'
+      });
+    })
+
+    it('should support deprecated context', function(){
+      var msg = new Facade({
+        context: {
+          providers: {
+            Salesforce: true
+          },
+          Salesforce: {
+            object: 'Lead',
+            lookup: { email: 'peter@initech.com' }
+          }
+        }
+      });
+
+      expect(msg.options('salesforce')).to.eql({
+        object: 'Lead',
+        lookup: { email: 'peter@initech.com' }
+      });
+    });
+  });
+
   describe('.one()', function(){
     var msg;
 


### PR DESCRIPTION
if we get a message like:

``` js
var context = {
  providers: {
    'Salesforce': true
  },
  'Salesforce': {
    object: 'Lead',
    lookup: { email: 'peter@initech.com' } }
  }
};

msg = new Facade({ context: context });
```

options method doesn't work properly:

``` js
msg.options('Salesforce'); // => {}
```

cc @calvinfo 
