### PR TITLE
Allow .userId to be snake cased

### DIFF
--- a/lib/alias.js
+++ b/lib/alias.js
@@ -66,6 +66,5 @@ Alias.prototype.previousId = function(){
 
 Alias.prototype.to =
 Alias.prototype.userId = function(){
-  return this.field('userId')
-    || this.field('to');
+  return this.field('userId') || this.field('user_id') || this.field('to');
 };

--- a/lib/facade.js
+++ b/lib/facade.js
@@ -319,7 +319,9 @@ Facade.prototype.timezone = Facade.proxy('context.timezone');
 Facade.prototype.timestamp = Facade.field('timestamp');
 Facade.prototype.channel = Facade.field('channel');
 Facade.prototype.ip = Facade.proxy('context.ip');
-Facade.prototype.userId = Facade.field('userId');
+Facade.prototype.userId = function() {
+  return this.field('userId') || this.field('user_id');
+};
 
 /**
  * Return the cloned and traversed object


### PR DESCRIPTION
This is currently breaking render-api-call in spec docs, which are
moving toward snake case.

Wanted to use this.proxy() but currently there's no guard against
infinite recursion in it in the case where you're asking for a
root-level property.