### PR TITLE
Page: enable "aliasing" of properties keys

### DIFF
--- a/lib/page.js
+++ b/lib/page.js
@@ -69,15 +69,28 @@ Page.prototype.referrer = function(){
 /**
  * Get the page properties mixing `category` and `name`.
  *
+ * @param {Object} aliases
  * @return {Object}
  */
 
-Page.prototype.properties = function(){
+Page.prototype.properties = function(aliases){
   var props = this.field('properties') || {};
   var category = this.category();
   var name = this.name();
+  aliases = aliases || {};
+
   if (category) props.category = category;
   if (name) props.name = name;
+
+  for (var alias in aliases) {
+    var value = null == this[alias]
+      ? this.proxy('properties.' + alias)
+      : this[alias]();
+    if (null == value) continue;
+    props[aliases[alias]] = value;
+    if (alias !== aliases[alias]) delete props[alias];
+  }
+
   return props;
 };
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "type-component": "0.0.1"
   },
   "devDependencies": {
+    "bluebird": "^2.9.27",
     "duo": "0.8.x",
     "duo-test": "0.3.x",
     "expect.js": "~0.2.0",

--- a/test/page.js
+++ b/test/page.js
@@ -70,6 +70,21 @@ describe('Page', function(){
         prop: true
       });
     })
+
+    it('should respect aliases', function(){
+      var page = new Page({
+        properties: { prop: true },
+        category: 'category',
+        name: 'name',
+      });
+
+      expect(page.properties({ name: 'pagename', prop: 'alias' })).to.eql({
+        category: 'category',
+        pagename: 'name',
+        alias: true
+      });
+    })
+
   })
 
   describe('.name()', function(){


### PR DESCRIPTION
This brings the behavior of `page.properties()` up to par with `track.properties()`, `identify.traits()`, and `group.traits()`, all of which take an optional `aliases` objects to rename keys in the object they return.

I actually assumed this was already here: https://github.com/segmentio/analytics.js-integrations/pull/634#discussion_r31291744

Think it makes sense we allow it given the pattern on the other message types.
