### PR TITLE
Update referrer methods on track and page.

### DIFF
--- a/lib/page.js
+++ b/lib/page.js
@@ -63,8 +63,9 @@ Page.prototype.url = Facade.proxy('properties.url');
  */
 
 Page.prototype.referrer = function() {
-  return this.proxy('properties.referrer')
-    || this.proxy('context.referrer.url');
+  return this.proxy('context.referrer.url')
+    || this.proxy('context.page.referrer')
+    || this.proxy('properties.referrer');
 };
 
 /**

--- a/lib/track.js
+++ b/lib/track.js
@@ -159,7 +159,12 @@ Track.prototype.currency = function() {
  * BACKWARDS COMPATIBILITY: should probably re-examine where these come from.
  */
 
-Track.prototype.referrer = Facade.proxy('properties.referrer');
+Track.prototype.referrer = function() {
+  return this.proxy('context.referrer.url')
+    || this.proxy('context.page.referrer')
+    || this.proxy('properties.referrer');
+};
+
 Track.prototype.query = Facade.proxy('options.query');
 
 /**

--- a/test/page.js
+++ b/test/page.js
@@ -112,6 +112,11 @@ describe('Page', function() {
       var page = new Page({ context: { referrer: { url: 'url' } } });
       expect(page.referrer()).to.eql('url');
     });
+
+    it('should proxy context.page.referrer', function() {
+      var page = new Page({ context: { page: { referrer: 'url' } } });
+      expect(page.referrer()).to.eql('url');
+    });
   });
 
   describe('.track()', function() {

--- a/test/track.js
+++ b/test/track.js
@@ -260,6 +260,16 @@ describe('Track', function() {
     it('should proxy the referrer', function() {
       expect(track.referrer()).to.eql(args.properties.referrer);
     });
+
+    it('should proxy context.referrer.url', function() {
+      var track = new Track({ context: { referrer: { url: 'url' } } });
+      expect(track.referrer()).to.eql('url');
+    });
+
+    it('should proxy context.page.referrer', function() {
+      var track = new Track({ context: { page: { referrer: 'url' } } });
+      expect(track.referrer()).to.eql('url');
+    });
   });
 
   describe('.username()', function() {


### PR DESCRIPTION
These will now look up `context.referrer.url` in addition to
`context.page.referrer` as per our spec.

`properties.referrer` is left as is for legacy purposes. But it will
lose priority to the other two.