### PR TITLE
add email helper to page/screen events

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ notifications:
   email:
   - engineering@segment.io
 node_js:
-- '0.12'
-- '0.11'
+- '4.1'
+- '4.0'
 - '0.10'
 env:
   global:

--- a/lib/page.js
+++ b/lib/page.js
@@ -2,6 +2,8 @@
 var inherit = require('./utils').inherit;
 var Facade = require('./facade');
 var Track = require('./track');
+var isEmail = require('is-email');
+
 
 /**
  * Expose `Page` facade
@@ -94,6 +96,20 @@ Page.prototype.properties = function(aliases) {
   }
 
   return props;
+};
+
+/**
+ * Get the user's email, falling back to their user ID if it's a valid email.
+ *
+ * @return {String}
+ */
+
+Page.prototype.email = function() {
+  var email = this.proxy('context.traits.email') || this.proxy('properties.email');
+  if (email) return email;
+
+  var userId = this.userId();
+  if (isEmail(userId)) return userId;
 };
 
 /**

--- a/test/page.js
+++ b/test/page.js
@@ -85,6 +85,30 @@ describe('Page', function() {
     });
   });
 
+  describe('.email()', function() {
+    var email = 'han@segment.com';
+
+    it('should proxy the email from properties', function() {
+      var page = new Page({ userId: 'x', properties: { email: email } });
+      expect(page.email()).to.eql(email);
+    });
+
+    it('should proxy the email from userId', function() {
+      var page = new Page({ userId: email });
+      expect(page.email()).to.eql(email);
+    });
+
+    it('should proxy the email from context.traits', function() {
+      var page = new Page({ context: { traits: { email: email }}});
+      expect(page.email()).to.eql(email);
+    });
+
+    it('should not error if there is no email', function() {
+      var page = new Page({});
+      expect(page.email()).to.eql(undefined);
+    });
+  });
+
   describe('.name()', function() {
     it('should proxy name', function() {
       expect(page.name()).to.eql(obj.name);

--- a/test/screen.js
+++ b/test/screen.js
@@ -72,6 +72,30 @@ describe('Screen', function() {
     });
   });
 
+  describe('.email()', function() {
+    var email = 'han@segment.com';
+
+    it('should proxy the email from properties', function() {
+      var screen = new Screen({ userId: 'x', properties: { email: email } });
+      expect(screen.email()).to.eql(email);
+    });
+
+    it('should proxy the email from userId', function() {
+      var screen = new Screen({ userId: email });
+      expect(screen.email()).to.eql(email);
+    });
+
+    it('should proxy the email from context.traits', function() {
+      var screen = new Screen({ context: { traits: { email: email }}});
+      expect(screen.email()).to.eql(email);
+    });
+
+    it('should not error if there is no email', function() {
+      var screen = new Screen({});
+      expect(screen.email()).to.eql(undefined);
+    });
+  });
+
   describe('.name()', function() {
     it('should proxy name', function() {
       expect(screen.name()).to.eql(obj.name);


### PR DESCRIPTION
`.page()` and `.screen()` is the only events that don't have `email` helper method.