### PR TITLE
Fix/revenue total completed order

### DIFF
--- a/lib/track.js
+++ b/lib/track.js
@@ -225,9 +225,10 @@ Track.prototype.email = function() {
 Track.prototype.revenue = function() {
   var revenue = this.proxy('properties.revenue');
   var event = this.event();
+  var orderCompletedRegExp = /^[ _]?completed[ _]?order[ _]?|^[ _]?order[ _]?completed[ _]?$/i;
 
   // it's always revenue, unless it's called during an order completion.
-  if (!revenue && event && event.match(/completed ?order/i)) {
+  if (!revenue && event && event.match(orderCompletedRegExp)) {
     revenue = this.proxy('properties.total');
   }
 

--- a/test/track.test.js
+++ b/test/track.test.js
@@ -9,7 +9,6 @@ describe('Track', function() {
     sessionId: 'abc123',
     properties: {
       revenue: '$50',
-      query: 'Shangri La',
       referrer: 'http://segment.io',
       username: 'calvinfo',
       email: 'test@segment.io'
@@ -243,7 +242,7 @@ describe('Track', function() {
     });
 
     it('should respect aliases', function() {
-      assert.deepEqual(track.properties({ revenue: 'amount', query: 'searchString' }), { referrer: 'http://segment.io', email: 'test@segment.io', username: 'calvinfo', amount: 50, searchString: 'Shangri La' });
+      assert.deepEqual(track.properties({ revenue: 'amount' }), { referrer: 'http://segment.io', email: 'test@segment.io', username: 'calvinfo', amount: 50 });
     });
 
     it('should traverse isodate', function() {

--- a/test/track.test.js
+++ b/test/track.test.js
@@ -9,6 +9,7 @@ describe('Track', function() {
     sessionId: 'abc123',
     properties: {
       revenue: '$50',
+      query: 'Shangri La',
       referrer: 'http://segment.io',
       username: 'calvinfo',
       email: 'test@segment.io'
@@ -242,7 +243,7 @@ describe('Track', function() {
     });
 
     it('should respect aliases', function() {
-      assert.deepEqual(track.properties({ revenue: 'amount' }), { referrer: 'http://segment.io', email: 'test@segment.io', username: 'calvinfo', amount: 50 });
+      assert.deepEqual(track.properties({ revenue: 'amount', query: 'searchString' }), { referrer: 'http://segment.io', email: 'test@segment.io', username: 'calvinfo', amount: 50, searchString: 'Shangri La' });
     });
 
     it('should traverse isodate', function() {


### PR DESCRIPTION
Update the regular expression in lib/track.js to accept both V1 and V2 of our ecommerce spec, specifically the `orderCompleted`, `completedOrder` event.