### PR TITLE
Fixed userAgent docs in facade readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ facade.timestamp(); // Thu Aug 29 2013 17:53:03 GMT-0700 (PDT)
 
 #### .userAgent()
 
-Returns the user agent for the call if passed into the `options.userAgent` field.
+Returns the user agent for the call if passed into the `context.userAgent` field.
 
 #### .active()
 

--- a/README.md
+++ b/README.md
@@ -99,19 +99,6 @@ facade.timestamp(); // Thu Aug 29 2013 17:53:03 GMT-0700 (PDT)
 
 Returns the user agent for the call if passed into the `options.userAgent` field.
 
-The user agent will be parsed by [component/user-agent-parser](https://github.com/component/user-agent-parser) and will store the full user agent under `facade.userAgent().full`;
-
-```javascript
-facade.userAgent();
-/*
-{
-browser : 'chrome',
-os : 'Mac OS X',
-full: 'Mozilla/5.0 (Macintosh; Intel Mac O...
-}
-*/
-```
-
 #### .active()
 
 Decides whether a call should be used to update the user who the call is for. Defaults to `true`, taken from `options.active`.


### PR DESCRIPTION
.userAgent() just returns the full userAgent string, not an object.

Is options the same as context? I feel like we use context more often now.