### PR TITLE
update .orderId and .[object]Id functions to support ecom spec v2

### DIFF
--- a/lib/track.js
+++ b/lib/track.js
@@ -59,7 +59,26 @@ Track.prototype.category = Facade.proxy('properties.category');
  * Ecommerce
  */
 
-Track.prototype.id = Facade.proxy('properties.id');
+/**
+ * `.id()`
+ * Now that Ecommerce Spec v2 prefixes the `id` with the object ie `product_id`, `promotion_id`
+ * exposing an argument for the object so we know what to look up!
+ *
+ * @param {string} object
+ * @return {string} object_id
+ */
+
+Track.prototype.id = function(object) {
+  var id;
+  if (object && typeof object === 'string') {
+    id = this.proxy('properties.' + object.toLowerCase() + '_id')
+      || this.proxy('properties.' + object.toLowerCase() + 'Id');
+  } else {
+    id = this.proxy('properties.id');
+  }
+  return id;
+};
+
 Track.prototype.sku = Facade.proxy('properties.sku');
 Track.prototype.tax = Facade.proxy('properties.tax');
 Track.prototype.name = Facade.proxy('properties.name');
@@ -89,7 +108,8 @@ Track.prototype.plan = Facade.proxy('properties.plan');
  */
 Track.prototype.orderId = function() {
   return this.proxy('properties.id')
-    || this.proxy('properties.orderId');
+    || this.proxy('properties.orderId')
+    || this.proxy('properties.order_id');
 };
 
 /**

--- a/lib/track.js
+++ b/lib/track.js
@@ -60,23 +60,40 @@ Track.prototype.category = Facade.proxy('properties.category');
  */
 
 /**
- * `.id()`
- * Now that Ecommerce Spec v2 prefixes the `id` with the object ie `product_id`, `promotion_id`
- * exposing an argument for the object so we know what to look up!
- *
- * @param {string} object
- * @return {string} object_id
+ * ids
  */
 
-Track.prototype.id = function(object) {
-  var id;
-  if (object && typeof object === 'string') {
-    id = this.proxy('properties.' + object.toLowerCase() + '_id')
-      || this.proxy('properties.' + object.toLowerCase() + 'Id');
-  } else {
-    id = this.proxy('properties.id');
-  }
-  return id;
+Track.prototype.id = Facade.proxy('properties.id');
+Track.prototype.productId = function() {
+  return this.proxy('properties.product_id') || this.proxy('properties.productId');
+};
+Track.prototype.promotionId = function() {
+  return this.proxy('properties.promotion_id') || this.proxy('properties.promotionId');
+};
+Track.prototype.cartId = function() {
+  return this.proxy('properties.cart_id') || this.proxy('properties.cartId');
+};
+Track.prototype.checkoutId = function() {
+  return this.proxy('properties.checkout_id') || this.proxy('properties.checkoutId');
+};
+Track.prototype.paymentId = function() {
+  return this.proxy('properties.payment_id') || this.proxy('properties.paymentId');
+};
+Track.prototype.couponId = function() {
+  return this.proxy('properties.coupon_id') || this.proxy('properties.couponId');
+};
+Track.prototype.wishlistId = function() {
+  return this.proxy('properties.wishlist_id') || this.proxy('properties.wishlistId');
+};
+Track.prototype.reviewId = function() {
+  return this.proxy('properties.review_id') || this.proxy('properties.reviewId');
+};
+
+Track.prototype.orderId = function() {
+  // doesn't follow above convention since this fallback order was how it used to be
+  return this.proxy('properties.id')
+    || this.proxy('properties.order_id')
+    || this.proxy('properties.orderId');
 };
 
 Track.prototype.sku = Facade.proxy('properties.sku');
@@ -100,17 +117,6 @@ Track.prototype.description = Facade.proxy('properties.description');
  */
 
 Track.prototype.plan = Facade.proxy('properties.plan');
-
-/**
- * Order id.
- *
- * @return {string}
- */
-Track.prototype.orderId = function() {
-  return this.proxy('properties.id')
-    || this.proxy('properties.orderId')
-    || this.proxy('properties.order_id');
-};
 
 /**
  * Get subtotal.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-require-path-exists": "^1.1.5",
     "expect.js": "^0.3.1",
     "istanbul": "^0.4.3",
-    "karma": "^0.13.22",
+    "karma": "^1.2.0",
     "karma-browserify": "^5.0.4",
     "karma-chrome-launcher": "^1.0.1",
     "karma-coverage": "^1.0.0",

--- a/test/track.test.js
+++ b/test/track.test.js
@@ -38,6 +38,11 @@ describe('Track', function() {
       var msg = new Track({ properties: { promotion_id: '1738' } });
       assert.strictEqual(msg.id('promotion'), '1738');
     });
+
+    it('should respect falback order: snake_case || camelCase', function() {
+      var msg = new Track({ properties: { order_id: 'yolo', orderId: 'yolo2' } }); 
+      assert.strictEqual(msg.id('order'), 'yolo');
+    });
   });
 
   describe('.sku()', function() {
@@ -262,6 +267,24 @@ describe('Track', function() {
     it('should proxy `order_id`', function() {
       var track = new Track({ properties: { order_id: 'id' } });
       assert.strictEqual(track.orderId(), 'id');
+    });
+
+    it('should respect fallback order: `id` || `orderId` || `order_id`', function() {
+      var props = {
+        id: '1',
+        orderId: '2',
+        order_id: '3'
+      };
+      var track = new Track({ properties: props });
+      assert.strictEqual(track.orderId(), '1');
+      
+      delete props.id;
+      var track2 = new Track({ properties: props });
+      assert.strictEqual(track2.orderId(), '2');
+
+      delete props.orderId;
+      var track3 = new Track({ properties: props });
+      assert.strictEqual(track3.orderId(), '3');
     });
   });
 

--- a/test/track.test.js
+++ b/test/track.test.js
@@ -24,24 +24,97 @@ describe('Track', function() {
   var track = new Track(args);
 
   describe('.id()', function() {
-    it('should proxy properties.id as default fallback', function() {
-      var msg = new Track({ properties: { id: '1738' } });
-      assert.strictEqual(msg.id(), '1738');
+    it('should proxy properties.id', function() {
+      var msg = new Track({ properties: { id: '12039' } });
+      assert.strictEqual(msg.id(), '12039');
     });
+  });
 
-    it('should proxy properties\' [object]Id', function() {
-      var msg = new Track({ properties: { productId: '1738' } });
-      assert.strictEqual(msg.id('product'), '1738');
+  describe('.productId()', function() {
+    it('should proxy properties.product_id', function() {
+      var msg = new Track({ properties: { product_id: '1738' } }); 
+      assert.strictEqual(msg.productId(), '1738');
     });
-
-    it('should proxy properties\' [object]_id', function() {
-      var msg = new Track({ properties: { promotion_id: '1738' } });
-      assert.strictEqual(msg.id('promotion'), '1738');
+    it('should proxy properties.productId', function() {
+      var msg = new Track({ properties: { productId: '1738' } }); 
+      assert.strictEqual(msg.productId(), '1738');
     });
+  });
 
-    it('should respect falback order: snake_case || camelCase', function() {
-      var msg = new Track({ properties: { order_id: 'yolo', orderId: 'yolo2' } }); 
-      assert.strictEqual(msg.id('order'), 'yolo');
+  describe('.promotionId()', function() {
+    it('should proxy properties.promotion_id', function() {
+      var msg = new Track({ properties: { promotion_id: '1738' } }); 
+      assert.strictEqual(msg.promotionId(), '1738');
+    });
+    it('should proxy properties.promotionId', function() {
+      var msg = new Track({ properties: { promotionId: '1738' } }); 
+      assert.strictEqual(msg.promotionId(), '1738');
+    });
+  });
+
+  describe('.cartId()', function() {
+    it('should proxy properties.cart_id', function() {
+      var msg = new Track({ properties: { cart_id: '1738' } }); 
+      assert.strictEqual(msg.cartId(), '1738');
+    });
+    it('should proxy properties.cartId', function() {
+      var msg = new Track({ properties: { cartId: '1738' } }); 
+      assert.strictEqual(msg.cartId(), '1738');
+    });
+  });
+
+  describe('.checkoutId()', function() {
+    it('should proxy properties.checkout_id', function() {
+      var msg = new Track({ properties: { checkout_id: '1738' } }); 
+      assert.strictEqual(msg.checkoutId(), '1738');
+    });
+    it('should proxy properties.checkoutId', function() {
+      var msg = new Track({ properties: { checkoutId: '1738' } }); 
+      assert.strictEqual(msg.checkoutId(), '1738');
+    });
+  });
+
+  describe('.paymentId()', function() {
+    it('should proxy properties.payment_id', function() {
+      var msg = new Track({ properties: { payment_id: '1738' } }); 
+      assert.strictEqual(msg.paymentId(), '1738');
+    });
+    it('should proxy properties.paymentId', function() {
+      var msg = new Track({ properties: { paymentId: '1738' } }); 
+      assert.strictEqual(msg.paymentId(), '1738');
+    });
+  });
+
+  describe('.couponId()', function() {
+    it('should proxy properties.coupon_id', function() {
+      var msg = new Track({ properties: { coupon_id: '1738' } }); 
+      assert.strictEqual(msg.couponId(), '1738');
+    });
+    it('should proxy properties.couponId', function() {
+      var msg = new Track({ properties: { couponId: '1738' } }); 
+      assert.strictEqual(msg.couponId(), '1738');
+    });
+  });
+
+  describe('.wishlistId()', function() {
+    it('should proxy properties.wishlist_id', function() {
+      var msg = new Track({ properties: { wishlist_id: '1738' } }); 
+      assert.strictEqual(msg.wishlistId(), '1738');
+    });
+    it('should proxy properties.wishlistId', function() {
+      var msg = new Track({ properties: { wishlistId: '1738' } }); 
+      assert.strictEqual(msg.wishlistId(), '1738');
+    });
+  });
+
+  describe('.reviewId()', function() {
+    it('should proxy properties.review_id', function() {
+      var msg = new Track({ properties: { review_id: '1738' } }); 
+      assert.strictEqual(msg.reviewId(), '1738');
+    });
+    it('should proxy properties.reviewId', function() {
+      var msg = new Track({ properties: { reviewId: '1738' } }); 
+      assert.strictEqual(msg.reviewId(), '1738');
     });
   });
 
@@ -267,24 +340,6 @@ describe('Track', function() {
     it('should proxy `order_id`', function() {
       var track = new Track({ properties: { order_id: 'id' } });
       assert.strictEqual(track.orderId(), 'id');
-    });
-
-    it('should respect fallback order: `id` || `orderId` || `order_id`', function() {
-      var props = {
-        id: '1',
-        orderId: '2',
-        order_id: '3'
-      };
-      var track = new Track({ properties: props });
-      assert.strictEqual(track.orderId(), '1');
-      
-      delete props.id;
-      var track2 = new Track({ properties: props });
-      assert.strictEqual(track2.orderId(), '2');
-
-      delete props.orderId;
-      var track3 = new Track({ properties: props });
-      assert.strictEqual(track3.orderId(), '3');
     });
   });
 

--- a/test/track.test.js
+++ b/test/track.test.js
@@ -23,6 +23,30 @@ describe('Track', function() {
 
   var track = new Track(args);
 
+  describe('.id()', function() {
+    it('should proxy properties.id as default fallback', function() {
+      var msg = new Track({ properties: { id: '1738' } });
+      assert.strictEqual(msg.id(), '1738');
+    });
+
+    it('should proxy properties\' [object]Id', function() {
+      var msg = new Track({ properties: { productId: '1738' } });
+      assert.strictEqual(msg.id('product'), '1738');
+    });
+
+    it('should proxy properties\' [object]_id', function() {
+      var msg = new Track({ properties: { promotion_id: '1738' } });
+      assert.strictEqual(msg.id('promotion'), '1738');
+    });
+  });
+
+  describe('.sku()', function() {
+    it('should proxy properties.sku', function() {
+      var msg = new Track({ properties: { sku: '12039' } });
+      assert.strictEqual(msg.sku(), '12039');
+    });
+  });
+
   describe('.repeat()', function() {
     it('should proxy properties.repeat', function() {
       var msg = new Track({ properties: { repeat: true } });
@@ -232,6 +256,11 @@ describe('Track', function() {
 
     it('should proxy `id`', function() {
       var track = new Track({ properties: { id: 'id' } });
+      assert.strictEqual(track.orderId(), 'id');
+    });
+
+    it('should proxy `order_id`', function() {
+      var track = new Track({ properties: { order_id: 'id' } });
       assert.strictEqual(track.orderId(), 'id');
     });
   });


### PR DESCRIPTION
This PR is so that our internal facade functions that are used in our integration code supports changes that occurred during ecommerce spec v1 -> v2 migration.

- .orderId() now will also look up `order_id`. Weirdly the precedence here is looking up `id` first over `orderId`... so to reduce breakage I've appended `order_id` as the last lookup. 
- .id() previously only looked up literally just `properties.id`. Since our new spec now updates all `id` properties with the object prefix (`product_id`, `order_id`, `promotion_id`), I'm updating the function so that you can pass what the object string you are trying to look up. 

So you'd be able to do something like this:

```
// arg is case insensitive
var orderId = track.id('order');
var promotionId = track.id('promotion');
var productId = track.id('product');
```

bonus: added a test for `.sku()` because we don't have one currently lol

@f2prateek @jgershen 