### PR TITLE
Change Facade.library() logic

### DIFF
--- a/lib/facade.js
+++ b/lib/facade.js
@@ -365,6 +365,7 @@ Facade.prototype.library = function() {
   var library = this.proxy('options.library');
   if (!library) return { name: 'unknown', version: null };
   if (typeof library === 'string') return { name: library, version: null };
+  if (typeof library.name !== 'string') library.name = 'unknown';
   return library;
 };
 


### PR DESCRIPTION
As currently written, Facade.library() will crash when called from Facade.device() if options.library is an object without a name property. This is because we will pass over both of the if statements in Facade.library() and attempt to run .indexOf() inside of Facade.device() on either an object literal or undefined.

This adds validation to ensure that library.name exists and is a string.