### PR TITLE
Remove Salesforce from default disabled integrations

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -267,15 +267,15 @@
                       </a></li>
                       
                       <li><a
-                        href='#facadestate'
-                        class='regular pre-open'>
-                        #state
-                      </a></li>
-                      
-                      <li><a
                         href='#facadezip'
                         class='regular pre-open'>
                         #zip
+                      </a></li>
+                      
+                      <li><a
+                        href='#facadecountry'
+                        class='regular pre-open'>
+                        #country
                       </a></li>
                       
                       <li><a
@@ -285,9 +285,9 @@
                       </a></li>
                       
                       <li><a
-                        href='#facadecountry'
+                        href='#facadestate'
                         class='regular pre-open'>
-                        #country
+                        #state
                       </a></li>
                       
                       <li><a
@@ -980,7 +980,7 @@
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/alias.js#L16-L18'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/alias.js#L16-L18'>
       <span>lib/alias.js</span>
       </a>
     
@@ -1095,7 +1095,7 @@
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/alias.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/alias.js#L27-L29'>
       <span>lib/alias.js</span>
       </a>
     
@@ -1158,7 +1158,7 @@
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/alias.js#L37-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/alias.js#L37-L37'>
       <span>lib/alias.js</span>
       </a>
     
@@ -1221,7 +1221,7 @@
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/alias.js#L47-L49'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/alias.js#L47-L49'>
       <span>lib/alias.js</span>
       </a>
     
@@ -1286,7 +1286,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/alias.js#L57-L57'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/alias.js#L57-L57'>
       <span>lib/alias.js</span>
       </a>
     
@@ -1349,7 +1349,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/alias.js#L67-L69'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/alias.js#L67-L69'>
       <span>lib/alias.js</span>
       </a>
     
@@ -1414,7 +1414,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/alias.js#L77-L77'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/alias.js#L77-L77'>
       <span>lib/alias.js</span>
       </a>
     
@@ -1483,7 +1483,7 @@ the spec.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/delete.js#L17-L19'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/delete.js#L17-L19'>
       <span>lib/delete.js</span>
       </a>
     
@@ -1607,7 +1607,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/delete.js#L28-L30'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/delete.js#L28-L30'>
       <span>lib/delete.js</span>
       </a>
     
@@ -1676,7 +1676,7 @@ the spec.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/facade.js#L37-L47'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/facade.js#L37-L47'>
       <span>lib/facade.js</span>
       </a>
     
@@ -1798,7 +1798,7 @@ on the inputted object.
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/facade.js#L108-L112'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/facade.js#L108-L112'>
       <span>lib/facade.js</span>
       </a>
     
@@ -1881,7 +1881,7 @@ returns a function that will always return <code>this.proxy(field)</code>.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/facade.js#L121-L125'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/facade.js#L121-L125'>
       <span>lib/facade.js</span>
       </a>
     
@@ -1958,7 +1958,7 @@ function that will always return <code>this.field(field)</code>.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/facade.js#L141-L149'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/facade.js#L141-L149'>
       <span>lib/facade.js</span>
       </a>
     
@@ -2044,7 +2044,7 @@ array, that will be returned. Otherwise, a one-element array containing
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/facade.js#L166-L173'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/facade.js#L166-L173'>
       <span>lib/facade.js</span>
       </a>
     
@@ -2139,7 +2139,7 @@ array the first element of that array will be returned. Otherwise,
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/facade.js#L71-L83'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/facade.js#L71-L83'>
       <span>lib/facade.js</span>
       </a>
     
@@ -2235,7 +2235,7 @@ is irrelevant.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/facade.js#L93-L96'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/facade.js#L93-L96'>
       <span>lib/facade.js</span>
       </a>
     
@@ -2313,7 +2313,7 @@ work</em> with this function.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/facade.js#L183-L187'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/facade.js#L183-L187'>
       <span>lib/facade.js</span>
       </a>
     
@@ -2378,7 +2378,7 @@ will be assigned as the property <code>type</code> of the outputted object.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/facade.js#L201-L210'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/facade.js#L201-L210'>
       <span>lib/facade.js</span>
       </a>
     
@@ -2460,7 +2460,7 @@ for. Casing does not matter.
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/facade.js#L215-L215'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/facade.js#L215-L215'>
       <span>lib/facade.js</span>
       </a>
     
@@ -2515,7 +2515,7 @@ for. Casing does not matter.
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/facade.js#L239-L266'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/facade.js#L239-L266'>
       <span>lib/facade.js</span>
       </a>
     
@@ -2606,7 +2606,7 @@ false.</li>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/facade.js#L284-L288'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/facade.js#L284-L288'>
       <span>lib/facade.js</span>
       </a>
     
@@ -2669,7 +2669,7 @@ false.</li>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/facade.js#L295-L297'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/facade.js#L295-L297'>
       <span>lib/facade.js</span>
       </a>
     
@@ -2732,7 +2732,7 @@ false.</li>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/facade.js#L305-L305'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/facade.js#L305-L305'>
       <span>lib/facade.js</span>
       </a>
     
@@ -2795,7 +2795,7 @@ false.</li>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/facade.js#L313-L313'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/facade.js#L313-L313'>
       <span>lib/facade.js</span>
       </a>
     
@@ -2858,7 +2858,7 @@ false.</li>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/facade.js#L339-L354'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/facade.js#L339-L354'>
       <span>lib/facade.js</span>
       </a>
     
@@ -2953,7 +2953,7 @@ facade.traits({ <span class="hljs-string">"sessionId"</span>: <span class="hljs-
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/facade.js#L364-L369'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/facade.js#L364-L369'>
       <span>lib/facade.js</span>
       </a>
     
@@ -3018,7 +3018,7 @@ version cannot be determined, it is set to <code>null</code>.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/facade.js#L379-L388'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/facade.js#L379-L388'>
       <span>lib/facade.js</span>
       </a>
     
@@ -3083,7 +3083,7 @@ are possible if the client is doing something unusual with <code>context.device<
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/facade.js#L399-L399'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/facade.js#L399-L399'>
       <span>lib/facade.js</span>
       </a>
     
@@ -3148,7 +3148,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/facade.js#L410-L410'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/facade.js#L410-L410'>
       <span>lib/facade.js</span>
       </a>
     
@@ -3213,7 +3213,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/facade.js#L418-L418'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/facade.js#L418-L418'>
       <span>lib/facade.js</span>
       </a>
     
@@ -3276,7 +3276,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/facade.js#L429-L429'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/facade.js#L429-L429'>
       <span>lib/facade.js</span>
       </a>
     
@@ -3341,7 +3341,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/facade.js#L440-L440'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/facade.js#L440-L440'>
       <span>lib/facade.js</span>
       </a>
     
@@ -3406,7 +3406,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/facade.js#L451-L451'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/facade.js#L451-L451'>
       <span>lib/facade.js</span>
       </a>
     
@@ -3457,72 +3457,6 @@ the spec.</p>
       </div>
     </div>
   
-    <div class='border-bottom' id='facadestate'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>state()</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/facade.js#L531-L531'>
-      <span>lib/facade.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Get the state from <code>traits</code>, <code>traits.address</code>, <code>properties</code>, or
-<code>properties.address</code>.</p>
-<p>This <em>should</em> be a string, but may not be if the client isn't adhering to
-the spec.</p>
-
-
-  <div class='pre p1 fill-light mt0'>state(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>:
-        
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
     <div class='border-bottom' id='facadezip'>
       <div class="clearfix small pointer toggle-sibling">
         <div class="py1 contain">
@@ -3537,7 +3471,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/facade.js#L531-L531'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/facade.js#L531-L531'>
       <span>lib/facade.js</span>
       </a>
     
@@ -3551,72 +3485,6 @@ the spec.</p>
 
 
   <div class='pre p1 fill-light mt0'>zip(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>:
-        
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='facadestreet'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>street()</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/facade.js#L531-L531'>
-      <span>lib/facade.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Get the street from <code>traits</code>, <code>traits.address</code>, <code>properties</code>, or
-<code>properties.address</code>.</p>
-<p>This <em>should</em> be a string, but may not be if the client isn't adhering to
-the spec.</p>
-
-
-  <div class='pre p1 fill-light mt0'>street(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
   
   
 
@@ -3669,7 +3537,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/facade.js#L531-L531'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/facade.js#L531-L531'>
       <span>lib/facade.js</span>
       </a>
     
@@ -3683,6 +3551,138 @@ the spec.</p>
 
 
   <div class='pre p1 fill-light mt0'>country(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>:
+        
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='facadestreet'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>street()</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/facade.js#L531-L531'>
+      <span>lib/facade.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Get the street from <code>traits</code>, <code>traits.address</code>, <code>properties</code>, or
+<code>properties.address</code>.</p>
+<p>This <em>should</em> be a string, but may not be if the client isn't adhering to
+the spec.</p>
+
+
+  <div class='pre p1 fill-light mt0'>street(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>:
+        
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='facadestate'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>state()</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/facade.js#L531-L531'>
+      <span>lib/facade.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Get the state from <code>traits</code>, <code>traits.address</code>, <code>properties</code>, or
+<code>properties.address</code>.</p>
+<p>This <em>should</em> be a string, but may not be if the client isn't adhering to
+the spec.</p>
+
+
+  <div class='pre p1 fill-light mt0'>state(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
   
   
 
@@ -3735,7 +3735,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/facade.js#L531-L531'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/facade.js#L531-L531'>
       <span>lib/facade.js</span>
       </a>
     
@@ -3801,7 +3801,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/facade.js#L531-L531'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/facade.js#L531-L531'>
       <span>lib/facade.js</span>
       </a>
     
@@ -3873,7 +3873,7 @@ the spec.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/group.js#L19-L21'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/group.js#L19-L21'>
       <span>lib/group.js</span>
       </a>
     
@@ -3997,7 +3997,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/group.js#L30-L32'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/group.js#L30-L32'>
       <span>lib/group.js</span>
       </a>
     
@@ -4060,7 +4060,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/group.js#L40-L40'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/group.js#L40-L40'>
       <span>lib/group.js</span>
       </a>
     
@@ -4123,7 +4123,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/group.js#L50-L50'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/group.js#L50-L50'>
       <span>lib/group.js</span>
       </a>
     
@@ -4188,7 +4188,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/group.js#L58-L65'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/group.js#L58-L65'>
       <span>lib/group.js</span>
       </a>
     
@@ -4252,7 +4252,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/group.js#L73-L78'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/group.js#L73-L78'>
       <span>lib/group.js</span>
       </a>
     
@@ -4316,7 +4316,7 @@ it looks like a valid email.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/group.js#L104-L119'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/group.js#L104-L119'>
       <span>lib/group.js</span>
       </a>
     
@@ -4412,7 +4412,7 @@ group.traits({ <span class="hljs-string">"sessionId"</span>: <span class="hljs-s
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/group.js#L130-L130'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/group.js#L130-L130'>
       <span>lib/group.js</span>
       </a>
     
@@ -4477,7 +4477,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/group.js#L141-L141'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/group.js#L141-L141'>
       <span>lib/group.js</span>
       </a>
     
@@ -4542,7 +4542,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/group.js#L152-L152'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/group.js#L152-L152'>
       <span>lib/group.js</span>
       </a>
     
@@ -4607,7 +4607,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/group.js#L160-L163'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/group.js#L160-L163'>
       <span>lib/group.js</span>
       </a>
     
@@ -4677,7 +4677,7 @@ simply an empty object.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/identify.js#L22-L24'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/identify.js#L22-L24'>
       <span>lib/identify.js</span>
       </a>
     
@@ -4801,7 +4801,7 @@ simply an empty object.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/identify.js#L33-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/identify.js#L33-L35'>
       <span>lib/identify.js</span>
       </a>
     
@@ -4864,7 +4864,7 @@ simply an empty object.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/identify.js#L43-L43'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/identify.js#L43-L43'>
       <span>lib/identify.js</span>
       </a>
     
@@ -4927,7 +4927,7 @@ simply an empty object.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/identify.js#L69-L84'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/identify.js#L69-L84'>
       <span>lib/identify.js</span>
       </a>
     
@@ -5023,7 +5023,7 @@ identify.traits({ <span class="hljs-string">"sessionId"</span>: <span class="hlj
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/identify.js#L95-L101'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/identify.js#L95-L101'>
       <span>lib/identify.js</span>
       </a>
     
@@ -5089,7 +5089,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/identify.js#L109-L112'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/identify.js#L109-L112'>
       <span>lib/identify.js</span>
       </a>
     
@@ -5153,7 +5153,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/identify.js#L120-L126'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/identify.js#L120-L126'>
       <span>lib/identify.js</span>
       </a>
     
@@ -5217,7 +5217,7 @@ or <code>traits.company.createdAt</code>.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/identify.js#L136-L138'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/identify.js#L136-L138'>
       <span>lib/identify.js</span>
       </a>
     
@@ -5282,7 +5282,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/identify.js#L149-L160'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/identify.js#L149-L160'>
       <span>lib/identify.js</span>
       </a>
     
@@ -5347,7 +5347,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/identify.js#L174-L184'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/identify.js#L174-L184'>
       <span>lib/identify.js</span>
       </a>
     
@@ -5415,7 +5415,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/identify.js#L198-L215'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/identify.js#L198-L215'>
       <span>lib/identify.js</span>
       </a>
     
@@ -5483,7 +5483,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/identify.js#L226-L228'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/identify.js#L226-L228'>
       <span>lib/identify.js</span>
       </a>
     
@@ -5549,7 +5549,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/identify.js#L238-L240'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/identify.js#L238-L240'>
       <span>lib/identify.js</span>
       </a>
     
@@ -5614,7 +5614,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/identify.js#L248-L255'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/identify.js#L248-L255'>
       <span>lib/identify.js</span>
       </a>
     
@@ -5678,7 +5678,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/identify.js#L266-L269'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/identify.js#L266-L269'>
       <span>lib/identify.js</span>
       </a>
     
@@ -5744,7 +5744,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/identify.js#L279-L282'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/identify.js#L279-L282'>
       <span>lib/identify.js</span>
       </a>
     
@@ -5809,7 +5809,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/identify.js#L293-L293'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/identify.js#L293-L293'>
       <span>lib/identify.js</span>
       </a>
     
@@ -5874,7 +5874,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/identify.js#L305-L305'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/identify.js#L305-L305'>
       <span>lib/identify.js</span>
       </a>
     
@@ -5940,7 +5940,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/identify.js#L317-L317'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/identify.js#L317-L317'>
       <span>lib/identify.js</span>
       </a>
     
@@ -6006,7 +6006,7 @@ adhering to the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/identify.js#L329-L329'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/identify.js#L329-L329'>
       <span>lib/identify.js</span>
       </a>
     
@@ -6072,7 +6072,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/identify.js#L341-L341'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/identify.js#L341-L341'>
       <span>lib/identify.js</span>
       </a>
     
@@ -6138,7 +6138,7 @@ adhering to the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/identify.js#L352-L352'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/identify.js#L352-L352'>
       <span>lib/identify.js</span>
       </a>
     
@@ -6203,7 +6203,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/identify.js#L363-L363'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/identify.js#L363-L363'>
       <span>lib/identify.js</span>
       </a>
     
@@ -6268,7 +6268,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/identify.js#L376-L376'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/identify.js#L376-L376'>
       <span>lib/identify.js</span>
       </a>
     
@@ -6341,7 +6341,7 @@ spec.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/page.js#L19-L21'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/page.js#L19-L21'>
       <span>lib/page.js</span>
       </a>
     
@@ -6465,7 +6465,7 @@ spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/page.js#L30-L32'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/page.js#L30-L32'>
       <span>lib/page.js</span>
       </a>
     
@@ -6528,7 +6528,7 @@ spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/page.js#L40-L40'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/page.js#L40-L40'>
       <span>lib/page.js</span>
       </a>
     
@@ -6591,7 +6591,7 @@ spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/page.js#L50-L50'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/page.js#L50-L50'>
       <span>lib/page.js</span>
       </a>
     
@@ -6656,7 +6656,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/page.js#L60-L60'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/page.js#L60-L60'>
       <span>lib/page.js</span>
       </a>
     
@@ -6721,7 +6721,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/page.js#L70-L70'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/page.js#L70-L70'>
       <span>lib/page.js</span>
       </a>
     
@@ -6786,7 +6786,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/page.js#L80-L80'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/page.js#L80-L80'>
       <span>lib/page.js</span>
       </a>
     
@@ -6851,7 +6851,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/page.js#L90-L90'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/page.js#L90-L90'>
       <span>lib/page.js</span>
       </a>
     
@@ -6916,7 +6916,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/page.js#L101-L105'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/page.js#L101-L105'>
       <span>lib/page.js</span>
       </a>
     
@@ -6982,7 +6982,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/page.js#L131-L150'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/page.js#L131-L150'>
       <span>lib/page.js</span>
       </a>
     
@@ -7078,7 +7078,7 @@ page.traits({ <span class="hljs-string">"sessionId"</span>: <span class="hljs-st
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/page.js#L161-L167'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/page.js#L161-L167'>
       <span>lib/page.js</span>
       </a>
     
@@ -7144,7 +7144,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/page.js#L178-L184'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/page.js#L178-L184'>
       <span>lib/page.js</span>
       </a>
     
@@ -7210,7 +7210,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/page.js#L193-L197'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/page.js#L193-L197'>
       <span>lib/page.js</span>
       </a>
     
@@ -7288,7 +7288,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/page.js#L206-L212'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/page.js#L206-L212'>
       <span>lib/page.js</span>
       </a>
     
@@ -7371,7 +7371,7 @@ converted to the Track's event name via <a href="#pageevent">Page#event</a>.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/screen.js#L21-L23'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/screen.js#L21-L23'>
       <span>lib/screen.js</span>
       </a>
     
@@ -7497,7 +7497,7 @@ instances of this class as well.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/screen.js#L32-L34'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/screen.js#L32-L34'>
       <span>lib/screen.js</span>
       </a>
     
@@ -7560,7 +7560,7 @@ instances of this class as well.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/screen.js#L42-L42'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/screen.js#L42-L42'>
       <span>lib/screen.js</span>
       </a>
     
@@ -7623,7 +7623,7 @@ instances of this class as well.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/screen.js#L51-L53'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/screen.js#L51-L53'>
       <span>lib/screen.js</span>
       </a>
     
@@ -7701,7 +7701,7 @@ instances of this class as well.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/screen.js#L62-L68'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/screen.js#L62-L68'>
       <span>lib/screen.js</span>
       </a>
     
@@ -7784,7 +7784,7 @@ converted to the Track's event name via <a href="#screenevent">Screen#event</a>.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L22-L24'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L22-L24'>
       <span>lib/track.js</span>
       </a>
     
@@ -7917,7 +7917,7 @@ converted to the Track's event name via <a href="#screenevent">Screen#event</a>.
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L33-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L33-L35'>
       <span>lib/track.js</span>
       </a>
     
@@ -7980,7 +7980,7 @@ converted to the Track's event name via <a href="#screenevent">Screen#event</a>.
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L43-L43'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L43-L43'>
       <span>lib/track.js</span>
       </a>
     
@@ -8043,7 +8043,7 @@ converted to the Track's event name via <a href="#screenevent">Screen#event</a>.
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L54-L54'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L54-L54'>
       <span>lib/track.js</span>
       </a>
     
@@ -8108,7 +8108,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L65-L65'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L65-L65'>
       <span>lib/track.js</span>
       </a>
     
@@ -8173,7 +8173,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L76-L76'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L76-L76'>
       <span>lib/track.js</span>
       </a>
     
@@ -8238,7 +8238,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L87-L87'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L87-L87'>
       <span>lib/track.js</span>
       </a>
     
@@ -8303,7 +8303,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L97-L99'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L97-L99'>
       <span>lib/track.js</span>
       </a>
     
@@ -8368,7 +8368,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L109-L111'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L109-L111'>
       <span>lib/track.js</span>
       </a>
     
@@ -8433,7 +8433,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L121-L123'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L121-L123'>
       <span>lib/track.js</span>
       </a>
     
@@ -8498,7 +8498,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L133-L135'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L133-L135'>
       <span>lib/track.js</span>
       </a>
     
@@ -8563,7 +8563,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L145-L147'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L145-L147'>
       <span>lib/track.js</span>
       </a>
     
@@ -8628,7 +8628,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L157-L159'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L157-L159'>
       <span>lib/track.js</span>
       </a>
     
@@ -8693,7 +8693,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L169-L171'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L169-L171'>
       <span>lib/track.js</span>
       </a>
     
@@ -8758,7 +8758,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L181-L183'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L181-L183'>
       <span>lib/track.js</span>
       </a>
     
@@ -8823,7 +8823,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L193-L198'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L193-L198'>
       <span>lib/track.js</span>
       </a>
     
@@ -8888,7 +8888,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L209-L209'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L209-L209'>
       <span>lib/track.js</span>
       </a>
     
@@ -8953,7 +8953,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L220-L220'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L220-L220'>
       <span>lib/track.js</span>
       </a>
     
@@ -9018,7 +9018,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L231-L231'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L231-L231'>
       <span>lib/track.js</span>
       </a>
     
@@ -9083,7 +9083,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L242-L242'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L242-L242'>
       <span>lib/track.js</span>
       </a>
     
@@ -9148,7 +9148,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L253-L253'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L253-L253'>
       <span>lib/track.js</span>
       </a>
     
@@ -9213,7 +9213,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L264-L264'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L264-L264'>
       <span>lib/track.js</span>
       </a>
     
@@ -9278,7 +9278,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L275-L275'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L275-L275'>
       <span>lib/track.js</span>
       </a>
     
@@ -9343,7 +9343,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L286-L286'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L286-L286'>
       <span>lib/track.js</span>
       </a>
     
@@ -9408,7 +9408,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L297-L297'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L297-L297'>
       <span>lib/track.js</span>
       </a>
     
@@ -9473,7 +9473,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L307-L309'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L307-L309'>
       <span>lib/track.js</span>
       </a>
     
@@ -9538,7 +9538,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L319-L321'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L319-L321'>
       <span>lib/track.js</span>
       </a>
     
@@ -9603,7 +9603,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L332-L332'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L332-L332'>
       <span>lib/track.js</span>
       </a>
     
@@ -9668,7 +9668,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L344-L344'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L344-L344'>
       <span>lib/track.js</span>
       </a>
     
@@ -9734,7 +9734,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L357-L374'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L357-L374'>
       <span>lib/track.js</span>
       </a>
     
@@ -9801,7 +9801,7 @@ tax, shipping, and discounts.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L382-L386'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L382-L386'>
       <span>lib/track.js</span>
       </a>
     
@@ -9865,7 +9865,7 @@ array, falling back to an empty array.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L394-L397'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L394-L397'>
       <span>lib/track.js</span>
       </a>
     
@@ -9929,7 +9929,7 @@ a quantity of one.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L405-L408'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L405-L408'>
       <span>lib/track.js</span>
       </a>
     
@@ -9993,7 +9993,7 @@ a quantity of one.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L419-L424'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L419-L424'>
       <span>lib/track.js</span>
       </a>
     
@@ -10059,7 +10059,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L435-L435'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L435-L435'>
       <span>lib/track.js</span>
       </a>
     
@@ -10124,7 +10124,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L460-L472'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L460-L472'>
       <span>lib/track.js</span>
       </a>
     
@@ -10219,7 +10219,7 @@ track.traits({ <span class="hljs-string">"sessionId"</span>: <span class="hljs-s
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L483-L488'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L483-L488'>
       <span>lib/track.js</span>
       </a>
     
@@ -10285,7 +10285,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L500-L508'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L500-L508'>
       <span>lib/track.js</span>
       </a>
     
@@ -10352,7 +10352,7 @@ the spec.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L522-L533'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L522-L533'>
       <span>lib/track.js</span>
       </a>
     
@@ -10420,7 +10420,7 @@ result will be parsed into a number.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L542-L545'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L542-L545'>
       <span>lib/track.js</span>
       </a>
     
@@ -10485,7 +10485,7 @@ for this event.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/a7cc955f57e14373bb4c502a3ea54a96d8aef9bc/lib/track.js#L556-L561'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/segmentio/facade/blob/02f30a8e60c3ca3faac4cca024675573cb64c765/lib/track.js#L556-L561'>
       <span>lib/track.js</span>
       </a>
     

--- a/lib/is-enabled.js
+++ b/lib/is-enabled.js
@@ -2,9 +2,7 @@
 
 // A few integrations are disabled by default. They must be explicitly enabled
 // by setting options[Provider] = true.
-var disabled = {
-  Salesforce: true
-};
+var disabled = {};
 
 /**
  * Check whether an integration should be enabled by default.

--- a/test/facade.test.js
+++ b/test/facade.test.js
@@ -244,7 +244,7 @@ describe('Facade', function() {
 
     it('should not get context for disabled by default integrations', function() {
       var facade = new Facade({});
-      assert.strictEqual(facade.context('Salesforce'), undefined);
+
       assert.deepEqual(facade.context('Customer.io'), {});
     });
 
@@ -280,7 +280,6 @@ describe('Facade', function() {
 
       assert.deepEqual(facade.context('HubSpot'), { setting: 'x' });
       assert.deepEqual(facade.context('Customer.io'), {});
-      assert.strictEqual(facade.context('Salesforce'), undefined);
     });
 
     it('should use obj-case', function() {
@@ -321,12 +320,12 @@ describe('Facade', function() {
       assert.strictEqual(facade.enabled('Google Analytics'), false);
     });
 
-    it('should only use disabled integrations when explicitly enabled', function() {
+    it.skip('should only use disabled integrations when explicitly enabled', function() {
       var facade = new Facade({});
       assert.strictEqual(facade.enabled('Salesforce'), false);
       facade = new Facade({ context: { Salesforce: { x: 1 } } });
       assert.strictEqual(facade.enabled('Salesforce'), true);
-    }).skip();
+    });
 
     it('should fall back to old providers api', function() {
       var providers = { 'Customer.io': false, Salesforce: true };

--- a/test/facade.test.js
+++ b/test/facade.test.js
@@ -326,7 +326,7 @@ describe('Facade', function() {
       assert.strictEqual(facade.enabled('Salesforce'), false);
       facade = new Facade({ context: { Salesforce: { x: 1 } } });
       assert.strictEqual(facade.enabled('Salesforce'), true);
-    });
+    }).skip();
 
     it('should fall back to old providers api', function() {
       var providers = { 'Customer.io': false, Salesforce: true };


### PR DESCRIPTION
Removes Salesforce from the map of disabled-by-default integrations. We are removing this in favor of a setting per a request from the routing team.

JIRA: https://segment.atlassian.net/browse/FCD-541