### PR TITLE
Remove type-component in favor of native functions

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+3.3.1 / 2020-11-06
+==================
+
+  * Remove third party library "type-component" in favor of native JS functions
 
 3.3.0 / 2020-09-23
 ==================

--- a/lib/facade.js
+++ b/lib/facade.js
@@ -6,7 +6,6 @@ import isEnabled from "./is-enabled";
 import newDate from "new-date";
 import objCase from "obj-case";
 import traverse from "@segment/isodate-traverse";
-import type from "type-component";
 
 /**
  * A *Facade* is an object meant for creating convience wrappers around
@@ -143,7 +142,7 @@ Facade.field = function (field) {
 Facade.multi = function (path) {
   return function () {
     let multi = this.proxy(path + "s");
-    if (type(multi) === "array") return multi;
+    if (Array.isArray(multi)) return multi;
     let one = this.proxy(path);
     if (one) one = [this.opts.clone ? clone(one) : one];
     return one || [];
@@ -170,7 +169,7 @@ Facade.one = function (path) {
     let one = this.proxy(path);
     if (one) return one;
     let multi = this.proxy(path + "s");
-    if (type(multi) === "array") return multi[0];
+    if (Array.isArray(multi)) return multi[0];
   };
 };
 
@@ -386,7 +385,7 @@ f.library = function () {
  */
 f.device = function () {
   let device = this.proxy("context.device");
-  if (type(device) !== "object") device = {};
+  if (typeof device !== "object") device = {};
   let library = this.library().name;
   if (device.type) return device;
 

--- a/lib/identify.js
+++ b/lib/identify.js
@@ -5,7 +5,6 @@ import get from "obj-case";
 import inherit from "inherits";
 import isEmail from "is-email";
 import newDate from "new-date";
-import type from "type-component";
 
 let trim = (str) => str.trim();
 
@@ -255,7 +254,7 @@ i.age = function () {
   let date = this.birthday();
   let age = get(this.traits(), "age");
   if (age != null) return age;
-  if (type(date) !== "date") return;
+  if (!(date instanceof Date)) return;
   let now = new Date();
   return now.getFullYear() - date.getFullYear();
 };

--- a/lib/track.js
+++ b/lib/track.js
@@ -1,7 +1,6 @@
 "use strict";
 
 import inherit from "inherits";
-import type from "type-component";
 import { Facade } from "./facade";
 import { Identify } from "./identify";
 import isEmail from "is-email";
@@ -407,7 +406,7 @@ t.subtotal = function () {
 t.products = function () {
   let props = this.properties();
   let products = get(props, "products");
-  return type(products) === "array" ? products : [];
+  return Array.isArray(products) ? products : [];
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "dist/index.js",
   "types": "index.d.ts",
   "scripts": {
+    "tdd": "jest --watch",
     "test": "make test",
     "build": "rm -rf dist && yarn tsc"
   },
@@ -25,8 +26,7 @@
     "inherits": "^2.0.1",
     "is-email": "0.1.0",
     "new-date": "github://segmentio/new-date",
-    "obj-case": "0.x",
-    "type-component": "0.0.1"
+    "obj-case": "0.x"
   },
   "devDependencies": {
     "@segment/isodate": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/facade",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Providing common fields for analytics integrations",
   "keywords": [],
   "main": "dist/index.js",


### PR DESCRIPTION
This PR removes the usage of `type-component` in favor of native functions, such as [typeof](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof), [instanceof](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof) and [Array.isArray()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray) - all supported by old browsers such as IE9.
