### PR TITLE
Upgrade a few external dependencies

### DIFF
--- a/lib/facade.js
+++ b/lib/facade.js
@@ -33,14 +33,14 @@ import traverse from "@segment/isodate-traverse";
  * @see {@link https://github.com/segmentio/new-date|new-date}
  * @see {@link https://github.com/segmentio/isodate-traverse|isodate-traverse}
  */
-export function Facade (obj, opts) {
+export function Facade (obj, opts = { clone: true, traverse: true }) {
   opts = opts || {};
-  if (!("clone" in opts)) opts.clone = true;
   if (opts.clone) obj = klona(obj);
-  if (!("traverse" in opts)) opts.traverse = true;
-  if (!("timestamp" in obj)) obj.timestamp = new Date();
-  else obj.timestamp = newDate(obj.timestamp);
+
+  obj.timestamp = ("timestamp" in obj) ? newDate(obj.timestamp) : new Date()
+
   if (opts.traverse) traverse(obj);
+
   this.opts = opts;
   this.obj = obj;
 }

--- a/lib/facade.js
+++ b/lib/facade.js
@@ -33,14 +33,14 @@ import traverse from "@segment/isodate-traverse";
  * @see {@link https://github.com/segmentio/new-date|new-date}
  * @see {@link https://github.com/segmentio/isodate-traverse|isodate-traverse}
  */
-export function Facade (obj, opts = { clone: true, traverse: true }) {
+export function Facade (obj, opts) {
   opts = opts || {};
+  if (!("clone" in opts)) opts.clone = true;
   if (opts.clone) obj = klona(obj);
-
-  obj.timestamp = ("timestamp" in obj) ? newDate(obj.timestamp) : new Date()
-
+  if (!("traverse" in opts)) opts.traverse = true;
+  if (!("timestamp" in obj)) obj.timestamp = new Date();
+  else obj.timestamp = newDate(obj.timestamp);
   if (opts.traverse) traverse(obj);
-
   this.opts = opts;
   this.obj = obj;
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "inherits": "^2.0.4",
     "klona": "^2.0.4",
     "new-date": "^1.0.3",
-    "obj-case": "0.2.0"
+    "obj-case": "0.2.1"
   },
   "devDependencies": {
     "@segment/isodate": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/facade",
-  "version": "3.3.8",
+  "version": "3.3.9",
   "description": "Providing common fields for analytics integrations",
   "keywords": [],
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
   },
   "homepage": "https://github.com/segmentio/facade#readme",
   "dependencies": {
-    "@segment/isodate-traverse": "^1.0.0",
-    "inherits": "^2.0.1",
+    "@segment/isodate-traverse": "^1.1.0",
+    "inherits": "^2.0.4",
     "klona": "^2.0.4",
     "new-date": "^1.0.2",
-    "obj-case": "0.x"
+    "obj-case": "0.2.0"
   },
   "devDependencies": {
     "@segment/isodate": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
   },
   "homepage": "https://github.com/segmentio/facade#readme",
   "dependencies": {
-    "@segment/isodate-traverse": "^1.1.0",
+    "@segment/isodate-traverse": "^1.1.1",
     "inherits": "^2.0.4",
     "klona": "^2.0.4",
-    "new-date": "^1.0.2",
+    "new-date": "^1.0.3",
     "obj-case": "0.2.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1289,22 +1289,17 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
-"@segment/isodate-traverse@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@segment/isodate-traverse/-/isodate-traverse-1.1.0.tgz#4fb36f30d94c2c5a3c8a75d25c1504822a1bb9ab"
-  integrity sha1-T7NvMNlMLFo8inXSXBUEgiobuas=
+"@segment/isodate-traverse@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@segment/isodate-traverse/-/isodate-traverse-1.1.1.tgz#37e1a68b5e48a841260145f1be86d342995dfc64"
+  integrity sha512-+G6e1SgAUkcq0EDMi+SRLfT48TNlLPF3QnSgFGVs0V9F3o3fq/woQ2rHFlW20W0yy5NnCUH0QGU3Am2rZy/E3w==
   dependencies:
-    "@segment/isodate" "^1.0.0"
-    component-each "^0.2.6"
-    component-type "^1.2.1"
+    "@segment/isodate" "^1.0.3"
 
-"@segment/isodate@1.0.2":
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/@segment/isodate/-/isodate-1.0.2.tgz#71fef69e816b77593a80b4cfbf2d22443222eafe"
-
-"@segment/isodate@^1.0.0", "@segment/isodate@^1.0.2":
+"@segment/isodate@1.0.3", "@segment/isodate@^1.0.2", "@segment/isodate@^1.0.3":
   version "1.0.3"
-  resolved "https://registry.npmjs.org/@segment/isodate/-/isodate-1.0.3.tgz#f44e8202d5edd277ce822785239474b2c9411d4a"
+  resolved "https://registry.yarnpkg.com/@segment/isodate/-/isodate-1.0.3.tgz#f44e8202d5edd277ce822785239474b2c9411d4a"
+  integrity sha512-BtanDuvJqnACFkeeYje7pWULVv8RgZaqKHWwGFnL/g/TH/CcZjkIVTfGDp/MAxmilYHUkrX70SqwnYSTNEaN7A==
 
 "@segment/to-iso-string@^1.0.0":
   version "1.0.1"
@@ -3456,28 +3451,9 @@ commondir@^1.0.1:
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
 
-component-each@^0.2.6:
-  version "0.2.6"
-  resolved "https://registry.npmjs.org/component-each/-/component-each-0.2.6.tgz#991faf31ef4fcafbad04237124d381b3394941d5"
-  dependencies:
-    component-type "1.0.0"
-    to-function "2.0.6"
-
 component-emitter@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
-
-component-props@*:
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/component-props/-/component-props-1.1.1.tgz#f9b7df9b9927b6e6d97c9bd272aa867670f34944"
-
-component-type@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/component-type/-/component-type-1.0.0.tgz#1ed8812e32dd65099d433570757f111ea3d3d871"
-
-component-type@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.npmjs.org/component-type/-/component-type-1.2.1.tgz#8a47901700238e4fc32269771230226f24b415a9"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -7685,12 +7661,12 @@ needle@^2.2.0:
     iconv-lite "^0.4.4"
     sax "^1.2.4"
 
-new-date@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/new-date/-/new-date-1.0.2.tgz#8d30622e41784667c3627ba4e0a1054bc3231e88"
-  integrity sha512-EjUPw3AGNS2J+jqtbYnzLj5YJXk69KcXnnmly0hGYWKCRWfkBLaqMchS7+or+u+/ibvz3We+bBakYiAfQgsC2A==
+new-date@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/new-date/-/new-date-1.0.3.tgz#a5956086d3f5ed43d0b210d87a10219ccb7a2326"
+  integrity sha512-0fsVvQPbo2I18DT2zVHpezmeeNYV2JaJSrseiHLc17GNOxJzUdx5mvSigPu8LtIfZSij5i1wXnXFspEs2CD6hA==
   dependencies:
-    "@segment/isodate" "1.0.2"
+    "@segment/isodate" "1.0.3"
 
 next-tick@1:
   version "1.0.0"
@@ -10075,12 +10051,6 @@ to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
   integrity sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=
-
-to-function@2.0.6:
-  version "2.0.6"
-  resolved "https://registry.npmjs.org/to-function/-/to-function-2.0.6.tgz#7d56cd9c3b92fa8dbd7b22e83d51924de740ebc5"
-  dependencies:
-    component-props "*"
 
 to-object-path@^0.3.0:
   version "0.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7841,10 +7841,10 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-obj-case@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/obj-case/-/obj-case-0.2.0.tgz#841c0b26784fc329968396fd871f830255c1ff2d"
-  integrity sha1-hBwLJnhPwymWg5b9hx+DAlXB/y0=
+obj-case@0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/obj-case/-/obj-case-0.2.1.tgz#13a554d04e5ca32dfd9d566451fd2b0e11007f1a"
+  integrity sha512-PquYBBTy+Y6Ob/O2574XHhDtHJlV1cJHMCgW+rDRc9J5hhmRelJB3k5dTK/3cVmFVtzvAKuENeuLpoyTzMzkOg==
 
 object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1289,9 +1289,10 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
-"@segment/isodate-traverse@^1.0.0":
+"@segment/isodate-traverse@^1.1.0":
   version "1.1.0"
-  resolved "https://registry.npmjs.org/@segment/isodate-traverse/-/isodate-traverse-1.1.0.tgz#4fb36f30d94c2c5a3c8a75d25c1504822a1bb9ab"
+  resolved "https://registry.yarnpkg.com/@segment/isodate-traverse/-/isodate-traverse-1.1.0.tgz#4fb36f30d94c2c5a3c8a75d25c1504822a1bb9ab"
+  integrity sha1-T7NvMNlMLFo8inXSXBUEgiobuas=
   dependencies:
     "@segment/isodate" "^1.0.0"
     component-each "^0.2.6"
@@ -5513,6 +5514,11 @@ inherits@2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
 
+inherits@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
 ini@^1.3.3, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
@@ -7859,9 +7865,10 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-obj-case@0.x:
+obj-case@0.2.0:
   version "0.2.0"
-  resolved "https://registry.npmjs.org/obj-case/-/obj-case-0.2.0.tgz#841c0b26784fc329968396fd871f830255c1ff2d"
+  resolved "https://registry.yarnpkg.com/obj-case/-/obj-case-0.2.0.tgz#841c0b26784fc329968396fd871f830255c1ff2d"
+  integrity sha1-hBwLJnhPwymWg5b9hx+DAlXB/y0=
 
 object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"


### PR DESCRIPTION
This PR upgrades 
- `isodate-traverse` and `new-date` - upgraded because they used different versions of `isodate`, resulting on duplicated dependencies being fetched and bundled in the Facade.
- `inherits` - for bug fixes and a smaller bundle size
- `obj-case` - Fix leaking global
