### PR TITLE
Use klona/full to clone objects created within iframes

### DIFF
--- a/lib/facade.js
+++ b/lib/facade.js
@@ -1,7 +1,7 @@
 "use strict";
 
 import address from "./address";
-import { klona } from "klona/lite";
+import { klona } from "klona/full";
 import isEnabled from "./is-enabled";
 import newDate from "new-date";
 import objCase from "obj-case";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/facade",
-  "version": "3.3.9",
+  "version": "3.3.10",
   "description": "Providing common fields for analytics integrations",
   "keywords": [],
   "main": "dist/index.js",


### PR DESCRIPTION
While testing a bug on AJS we realized `klona/lite` is not able to clone objects created within iframes.
There's a bigger discussion [here](https://stackoverflow.com/questions/4347298/use-of-tostring-instead-of-constructor-in-javascript) about how objects created in different DOM Frames are created with different prototypes.

We realized `klona/full` is able to clone these objects, so this PR switches `klona` to use its full version instead of lite. 

## Testing
With `klona/full`, we're able to fully clone the `properties` object of a track call:
https://user-images.githubusercontent.com/484013/121435030-17846600-c933-11eb-8384-dd56e6128527.mov

