### PR TITLE
add .rawEvent() method

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,6 @@ workflows:
             - test
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)*(-.+)?/
+              only: /v?[0-9]+(\.[0-9]+)*(-.+)?/
             branches:
               ignore: /.*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -33,6 +33,17 @@ declare module '@segment/facade' {
      *
      */
     json(): { [key: string]: any };
+
+    /**
+     * Gets the raw, unmodified object this facade wraps around.
+     * 
+     * Unlike the `json` method, which does make some subtle modifications 
+     * to datetime values and the `type` property, this method returns the input
+     * object as-is. It is not guaranteed to be the same instance, due to constraints of 
+     * how the `clone: false` option behaves.
+     */
+    rawEvent(): { [key: string]: any }
+
     /**
      * Get the options of a call. If an integration is passed, only the options for
      * that integration are included. If the integration is not enabled, then

--- a/lib/facade.js
+++ b/lib/facade.js
@@ -36,7 +36,12 @@ import traverse from "@segment/isodate-traverse";
 export function Facade (obj, opts) {
   opts = opts || {};
   if (!("clone" in opts)) opts.clone = true;
-  if (opts.clone) obj = klona(obj);
+  if (opts.clone) {
+    this.raw = obj;
+    obj = klona(obj);
+  } else {
+    this.raw = klona(obj);
+  }
   if (!("traverse" in opts)) opts.traverse = true;
   if (!("timestamp" in obj)) obj.timestamp = new Date();
   else obj.timestamp = newDate(obj.timestamp);
@@ -185,6 +190,19 @@ f.json = function() {
   let ret = this.opts.clone ? klona(this.obj) : this.obj;
   if (this.type) ret.type = this.type();
   return ret;
+};
+
+/**
+ * Gets the raw, unmodified object this facade wraps around.
+ * 
+ * Unlike the `json` method which does make some subtle modifications 
+ * to datetime values and the `type` property. This method returns the input
+ * object instance.
+ * 
+ * @return {Object}
+ */
+f.rawEvent = function() {
+  return this.raw;
 };
 
 /**

--- a/test/facade.test.js
+++ b/test/facade.test.js
@@ -229,6 +229,27 @@ describe("Facade", function () {
     });
   });
 
+  describe(".rawEvent()", function () {
+    it("should return the input object unmodified", function () {
+      var obj = {
+        a: "b", c: "d", x: [1, 2, 3], 
+        properties: {  iso_date_string: new Date().toISOString() }
+      };
+      var facade = new Facade(obj);
+      deepEqual(facade.rawEvent(), obj);
+    });
+
+    it("should not add .type", function () {
+      var track = new Track({});
+      deepEqual(track.rawEvent().type, undefined);
+    });
+
+    it("should not add .timestamp", function () {
+      var track = new Track({});
+      deepEqual(track.rawEvent().timestamp, undefined);
+    });
+  });
+
   describe(".context()", function () {
     it('should pull from "context" for backwards compatibility', function () {
       var options = { a: "b" };


### PR DESCRIPTION
This PR introduces a way to consistently get the raw input event unmodified. It cannot guarantee returning the same _instance_ due to the nature of how `clone: false` behaves (it will mutate the input object). To achieve this we only deep-clone the input if `clone: false`. Otherwise, we keep track of the input object on `this.raw` before it gets cloned and mutated.