### PR TITLE
always clone raw event, for consistency

### DIFF
--- a/lib/facade.js
+++ b/lib/facade.js
@@ -35,13 +35,9 @@ import traverse from "@segment/isodate-traverse";
  */
 export function Facade (obj, opts) {
   opts = opts || {};
+  this.raw = klona(obj);
   if (!("clone" in opts)) opts.clone = true;
-  if (opts.clone) {
-    this.raw = obj;
-    obj = klona(obj);
-  } else {
-    this.raw = klona(obj);
-  }
+  if (opts.clone) obj = klona(obj);
   if (!("traverse" in opts)) opts.traverse = true;
   if (!("timestamp" in obj)) obj.timestamp = new Date();
   else obj.timestamp = newDate(obj.timestamp);
@@ -193,11 +189,11 @@ f.json = function() {
 };
 
 /**
- * Gets the raw, unmodified object this facade wraps around.
+ * Gets a copy of the unmodified input object this facade wraps around.
  * 
  * Unlike the `json` method which does make some subtle modifications 
- * to datetime values and the `type` property. This method returns the input
- * object instance.
+ * to datetime values and the `type` property. This method returns a copy of 
+ * the unmodified input object
  * 
  * @return {Object}
  */


### PR DESCRIPTION
Rather than sometimes cloning, sometimes not, this PR introduces consistent cloning of the input object to be used with `rawEvent`