### PR TITLE
Handle null on context.device for facade

### DIFF
--- a/lib/facade.js
+++ b/lib/facade.js
@@ -403,7 +403,9 @@ f.library = function() {
  */
 f.device = function() {
   let device = this.proxy("context.device");
-  if (typeof device !== "object") device = {};
+  if (typeof device !== "object" || device === null) {
+    device = {};
+  }
   let library = this.library().name;
   if (device.type) return device;
 

--- a/test/facade.test.js
+++ b/test/facade.test.js
@@ -527,6 +527,11 @@ describe("Facade", function () {
       deepEqual(facade.device(), { token: "token" });
     });
 
+    it("should handle device set as null", function () {
+      var facade = new Facade({ context: { device: null } }, {clone: true});
+      deepEqual(facade.device(), {});
+    });
+
     it("should leave existing device-types untouched", function () {
       var facade = new Facade({
         context: {


### PR DESCRIPTION
This PR adds handling of null values in `context.device` for `Facade.device()`, fixing errors like https://sentry.io/organizations/segment/issues/2502477494/?environment=production&project=1110287&referrer=alert_email
