### PR TITLE
Remove nulls for track.products()

### DIFF
--- a/lib/track.js
+++ b/lib/track.js
@@ -406,7 +406,10 @@ t.subtotal = function () {
 t.products = function () {
   let props = this.properties();
   let products = get(props, "products");
-  return Array.isArray(products) ? products : [];
+  if (Array.isArray(products)) {
+    return products.filter(item => item !== null)
+  }
+  return [];
 };
 
 /**

--- a/test/track.test.js
+++ b/test/track.test.js
@@ -341,6 +341,28 @@ describe("Track", function () {
       var track = new Track({ properties: { Products: [{}] } });
       deepEqual(track.products(), [{}]);
     });
+
+    it("should return empty array", function () {
+      const track = new Track({ properties: { product: [] } });
+      deepEqual(track.products(), []);
+    });
+
+    it("should return an array of products without nulls", function () {
+      const products = [
+        null,
+        { 'product_id': '1'},
+        null,
+        { 'product_id': '2'},
+        { 'product_id': '3'}
+      ]
+      const track = new Track({ properties: { products } });
+      const expectedProducts = [
+        { 'product_id': '1'},
+        { 'product_id': '2'},
+        { 'product_id': '3'}
+      ]
+      deepEqual(track.products(), expectedProducts);
+    });
   });
 
   describe(".orderId()", function () {


### PR DESCRIPTION
This PR removes `null`s from the product array to address issues when trying to access product properties in integrations mono-service.

Sentry error: https://sentry.io/organizations/segment/issues/2455344070/?environment=production&project=1110287&query=is%3Aunresolved

## Does this PR change the behavior of any of the following fields?

* context
* email
* event
* groupId
* options
* traits
* userId
* writeKey

If so or if there is any doubt, please add @anoonan and @stevevls as reviewers. There is a parallel Go implementation of 
those fields in [integrations-consumer](https://github.com/segmentio/integrations-consumer), so any changes **must** be
reflected there there.  

Failure to keep them in sync, it will *probably result in a SEV*.