### PR TITLE
inline sources for sourceMaps

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "esModuleInterop": true,
     "strict": true,
     "sourceMap": true,
+    "inlineSources": true,
     "incremental": true,
     "outDir": "dist",
     "noUnusedLocals": true,


### PR DESCRIPTION
Fixes #173 and https://github.com/segmentio/analytics-next/issues/420

This update inlines the sources in the source maps so that tooling can parse the sourcemaps correctly.

Tested this change with a cra5 app using `@segment/analytics-next`